### PR TITLE
03.14 [코카콜라] 코어자바스크립트 (p.29~p.35) 

### DIFF
--- a/coke/core-javascript/03.14[코카콜라]-코어자바스크립트(p.29~p.35).md
+++ b/coke/core-javascript/03.14[코카콜라]-코어자바스크립트(p.29~p.35).md
@@ -1,0 +1,59 @@
+## 코어자바스크립트(p.29~p.35)
+
+- undefined와 null
+
+---
+
+# 배운 점(Facts)
+
+## undefined
+
+- 개발자가 undefined 값으로 할당한다.
+- 자바스크립트 엔진이 자동으로 부여한다.
+
+### 자바스크립트 엔진이 자동으로 undefined값으로 할당 할 경우
+
+- 값을 대입하지 않은 변수, 즉 데이터 영역의 메모리 주소를 지정하지 않은 식별자에 접근할 떄
+- 객체 내부의 존재하지 않는 프로퍼티에 접근하려고 할 때
+- return 문이 없거나 호출되지 않는 함수의 실행 결과
+
+### undefined와 배열
+
+```javascript
+var arr1 = [];
+arr1.length = 3;
+console.log(arr1); // [empty x 3] 비어있는 배열
+
+var arr2 = new Array(3);
+console.log(arr2); // [empty x 3] 비어있는 배열
+
+var arr3 = [undefined, undefined, undefined];
+console.log(arr3); // [undefined, undefined, undefined] undefined를 할당한 배열
+
+arr2[1] = 1;
+arr2.forEach((value, index) => console.log(value, index)); // 1 1
+arr3.forEach((value, index) => console.log(value, index)); // undefined 0 / undefined 1 / undefined 2
+```
+
+**비어있는 요소는 순회와 관련된 많은 배열 메서드들의 순회 대상에서 제외된다**
+
+```javascript
+const arr1 = new Array(3);
+console.log(arr1[1]); // undefined
+```
+
+- 배열도 객체이기 때문에 존재하지 않는 프로퍼티를 순회 하는 것은 불가능하다.
+- 배열의 값이 지정되지 않는 인덱스를 접근하면 undefined가 반환 되는 것은 자바스크립트 엔진이 자동으로 undefined를 할당하기 때문이다.(앞서 말했던 객체 내부의 존재하지 않는 프로퍼티에 접근하려고 할 때)
+
+**따라서 개발자가 직접적으로 undefined를 할당 할 필요는 없다. 값이 비어 있다고 할때는 null을 할당 하자!!!**
+
+## null
+
+- null은 사용자가 명시적으로 '없음'을 표현하기 위해 대입한 값이다.
+- 없음을 표현 할려면 undefined 대신 null을 사용하자.
+
+---
+
+# 회고(Feelings)
+
+- '비어있는 요소는 순회와 관련된 많은 배열 메서드들의 순회 대상에서 제외된다' 라는걸 이번에 처음 알게 되었다. 알고리즘 풀때 배열의 요소가 비어 있어도 순회 하는줄 알아서 스트레스 받았는데 이제 그런 생각 안해도 될듯 싶다.


### PR DESCRIPTION
- '없음'을 할당 할때는 undefined 대신에 null을 할당하자
- 배열의 비어있는 요소는 순회와 관련된 많은 배열 메서드들의 순회 대상에서 제외된다
