### PR TITLE
3.18 [꼬재] 코어 자바스크립트 p178 ~ p188

### DIFF
--- a/꼬재/02_Core_Javascript/07_클래스/README.md
+++ b/꼬재/02_Core_Javascript/07_클래스/README.md
@@ -4,3 +4,101 @@
 
 자바스크립트는 프로토타입 기반 언어라서 '상속' 개념이 존재하지 않았었다.
 ES6에는 클래스 문법이 추가되었지만, 일정 부분은 프로토타입을 활용하고 있기 때문에, ES5 체제 하에서 클래스를 흉내내기 위한 구현 방식을 학습하는 것은 많은 도움이 된다.
+
+## 02 자바스크립트의 클래스
+
+---
+
+생성자 함수 Array를 new 연산자와 함께 호출하면 인스턴스가 생성된다.
+이때 Array를 일종의 클래스라고 하면, Array의 prototype 객체 내부 요소들이 인스턴스에 '상속'된다고 할 수 있다.
+(실제로는 프로토타입 체이닝에 의한 참조이다.)
+
+인스턴스에 상속되는지(인스턴스가 참조하는지) 여부에 따라 static 멤버와 instance 멤버로 나뉜다.
+자바스크립트에서는 인스턴스에도 직접 메서드를 정의할 수 있다.
+이를 '인스턴스 메서드'라 하기보다는 '프로토타입 메서드'라 부르는게 더 적합하고, 대중적인 표현이다.
+
+```js
+// 생성자
+const Rectangle = function (width, height) {
+  this.width = width;
+  this.height = height;
+};
+
+// 프로토 타입 메서드
+Rectangle.prototype.getArea = function () {
+  return this.width * this.height;
+};
+
+// 스태틱 메서드
+Rectangle.isRectangle = function (instance) {
+  return (
+    instance instanceof Rectangle && instance.width > 0 && instance.height > 0
+  );
+};
+
+const rect1 = new Rectangle(3, 4);
+console.log(rect1.getArea()); // 12
+console.log(rect1.isRectangle(rect1)); // TypeError
+console.log(Rectangle.isRectangle(rect1)); // true
+```
+
+위 예제에서 보면 알 수 있듯
+즉, instance에서는 class의 프로토타입 프로퍼티, 프로토타입 메서드에는 접근이 가능하고, 스태틱 프로퍼티, 스태틱 메서드에는 접근이 불가능하다.
+
+## 03 클래스 상속
+
+---
+
+사용자가 정의한 Rectangle, Square 클래스 사이에서 상속관계를 구현하는 예제를 진행해보자.
+
+```js
+// Rectangel 생성자
+const Rectangle = function (width, height) {
+  this.width = width;
+  this.height = height;
+};
+
+// Rectangle 프로토타입 메서드
+Rectangle.prototype.getArea = function () {
+  return this.width * this.height;
+};
+
+// 인스턴스 생성
+const rect = new Rectangle(3, 4);
+console.log(rect.getArea()); // 12
+
+// Square 생성자
+const Square = function (width) {
+  this.width = width;
+};
+
+// Square 프로토타입 메서드
+Square.prototype.getArea = function () {
+  return this.width * this.width;
+};
+
+const sq = new Square(5);
+console.log(sq.getArea()); // 25
+```
+
+```js
+// Rectangel 생성자
+const Rectangle = function (width, height) {
+  this.width = width;
+  this.height = height;
+};
+
+// Rectangle 프로토타입 메서드
+Rectangle.prototype.getArea = function () {
+  return this.width * this.height;
+};
+
+// Square 생성자
+const Square = function (width) {
+  // Rectangle의 생성자 함수를 함수로써 호출
+  Rectangle.call(this, width, width);
+};
+```
+
+이처럼 Square의 prototype에 상위 클래스인 Rectangle의 인스턴스를 부여하는 것으로 기본적인 메서드 상속은 가능하지만 다양한 문제가 발생할 여지가 있다.
+예를 들어, 생성자 함수를 가르키는 것이 Square가 아니라 Rectangle을 가리키는 점과 Square의 width값을 지우더라도, Rectangle의 width값을 참조할 수 있는 점이 있다.


### PR DESCRIPTION
자바스크립트에서는 인스턴스에도 직접 메서드를 정의할 수 있다.
이를 '인스턴스 메서드'라 하기보다는 '프로토타입 메서드'라 부르는게 더 적합하고, 대중적인 표현이다.
즉, 인스턴스에서는 class의 프로토타입 프로퍼티, 프로토타입 메서드에는 접근이 가능하고, 스태틱 프로퍼티, 스태틱 메서드에는 접근이 불가능하다.
